### PR TITLE
Fix electron build path resolution and sort client dropdown alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:electron": "electron .",
     "build": "vite build",
     "dev": "vite",
-    "build:legacy": "esbuild src/firebase-bundle.js --bundle --outfile=dist/firebase-bundle.js --format=iife --global-name=UltraphonicsFirebase --minify && esbuild src/main.js src/quote.js src/contact.js src/media-kit.js src/services.js src/weddings.js src/live-viewer.js --bundle --outdir=dist --format=iife --minify",
+    "build:legacy": "esbuild ./src/firebase-bundle.js --bundle --outfile=dist/firebase-bundle.js --format=iife --global-name=UltraphonicsFirebase --minify && esbuild ./src/main.js ./src/quote.js ./src/contact.js ./src/media-kit.js ./src/services.js ./src/weddings.js ./src/live-viewer.js --bundle --outdir=dist --format=iife --minify",
     "build:dev": "vite build --mode development",
     "build:icons": "bash scripts/prepare-icons.sh",
     "package:mac": "yarn build:legacy && yarn build:icons && electron-builder --mac --publish never",

--- a/src/pages/ShowManager.jsx
+++ b/src/pages/ShowManager.jsx
@@ -719,7 +719,7 @@ function ShowEditForm({ form, setField, setFields, clients, setlists, onClientCh
   const [guestInstrument, setGuestInstrument] = useState('Guitar');
   const [addingGuest, setAddingGuest] = useState(false);
 
-  const activeClients = clients.filter(c => (c.status || 'Active') === 'Active');
+  const activeClients = clients.filter(c => (c.status || 'Active') === 'Active').sort((a, b) => (a.name || '').localeCompare(b.name || ''));
   const selectedClient = clients.find(c => c.id === form.clientId);
 
   function addGuest() {


### PR DESCRIPTION
- Prefix all esbuild entry point paths with ./ so esbuild treats them as relative file paths rather than node module lookups (fixes CI)
- Sort active clients alphabetically in show edit form dropdown